### PR TITLE
Exposes :MacDownPreview command for vimscript use

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,8 +17,23 @@ To install `macdown.vim`, use your favorite Vim plugin manager (e.g.
 Plug 'hashrocket/vim-macdown'
 ```
 
+
+**On demand**:
+
+* `<leader>p` (`\p` with default vim config)
+* `:MacDownPreview` to invoke by name or in a script
+
 Make some edits to a markdown file and then hit `<leader>p` to view a
 preview in Macdown.
+
+**On save for *.md files**:
+
+Add the following to your `.vimrc`:
+
+```vimscript
+" execute commands on filetype save
+autocmd BufWritePost *.md exec :MacDownPreview
+```
 
 ### License
 

--- a/plugin/macdown.vim
+++ b/plugin/macdown.vim
@@ -84,8 +84,9 @@ function! MacDownHandleDownloadFinished(job, status)
 endfunction
 
 command InstallMacDown :execute s:InstallMacDown()
+command MacDownPreview :call <SID>MacDownMarkdownPreview()
 
-nnoremap <leader>p :call <SID>MacDownMarkdownPreview()<cr>
+nnoremap <leader>p :MacDownPreview<cr>
 
 
 let &cpo = s:save_cpo


### PR DESCRIPTION
Been enjoying this enough to want to trigger it automatically on save. I couldn't see a way to do so without exposing a new vimscript `command` so here it is!

![image](https://user-images.githubusercontent.com/147981/86950732-260c4100-c116-11ea-9038-45e5fdbe24a3.png)
