### PR TITLE
Add some new commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@
 
 ## Usage
 
+### Installation
+
 Using this plugin requires two things:
 
 - You are on a Mac
@@ -17,31 +19,51 @@ To install `macdown.vim`, use your favorite Vim plugin manager (e.g.
 Plug 'hashrocket/vim-macdown'
 ```
 
-
-**On demand**:
+### Commands
 
 * `<leader>p` (`\p` with default vim config)
-* `:MacDownPreview` to invoke by name or in a script
+* `:MacDownPreview` to open the current file in MacDown
+* `:MacDownClose` to close MacDown
+* `:MacDownExit` to close MacDown, but wait for the close to finish before returning focus to Vim (Necessary while exiting vim)
+* `:MacDownOff` to disable this plugin during the current vim session
+* `:MacDownOn` to enable (default) this plugin during the current vim session
 
 Make some edits to a markdown file and then hit `<leader>p` to view a
 preview in Macdown.
 
-**On save for *.md files**:
+### .vimrc
 
 Add the following to your `.vimrc`:
+
+#### On save for .md files
 
 ```vimscript
 " execute commands on filetype save
 autocmd BufWritePost *.md exec :MacDownPreview
 ```
 
-### License
+#### On close .md file
+
+```vimscript
+" Enable closing MacDown when ':q' closes the current file, but doesn't
+" exit vim from vim-macdown plugin
+autocmd BufWinLeave *.md :MacDownClose
+```
+
+#### On close .md file and exit vim
+
+```vimscript
+" Enable closing MacDown when ':q' exits vim from vim-macdown plugin
+autocmd VimLeavePre *.md :MacDownExit
+```
+
+## License
 
 macdown.vim is released under the [MIT License](http://www.opensource.org/licenses/MIT).
 
 ---
 
-### About
+## About
 
 [![Hashrocket logo](https://hashrocket.com/hashrocket_logo.svg)](https://hashrocket.com)
 


### PR DESCRIPTION
Add the following commands:
* `:MacDownClose` to close MacDown
* `:MacDownExit` to close MacDown, but wait for the close to finish before returning focus to Vim (Necessary while exiting vim)
* `:MacDownOff` to disable this plugin during the current vim session
* `:MacDownOn` to enable (default) this plugin during the current vim session